### PR TITLE
Include git tests in coverage reporter

### DIFF
--- a/.coverage.smalltalk.ston
+++ b/.coverage.smalltalk.ston
@@ -1,4 +1,8 @@
 SmalltalkCISpec {
+  #preTesting : SCICustomScript {
+    #path : 'scripts/preTesting.st',
+    #platforms : [ #squeak ]
+  },
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'Algernon',


### PR DESCRIPTION
To cover the git test, the CI, for the coverage needs to load in the Squit browser